### PR TITLE
Enhance workflow with manual dispatch and inputs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,7 +5,12 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  workflow_dispatch: # Позволяет запускать вручную
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to checkout and run workflow'
+        required: true
+        default: 'main'
 
 permissions:
   contents: read
@@ -16,6 +21,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.commit_sha }}
 
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/python-app.yml` to allow manual workflow runs with a specified commit SHA. This enhancement enables more flexible and targeted workflow executions.

Workflow dispatch improvements:

* Added an input parameter `commit_sha` to the `workflow_dispatch` trigger, allowing users to specify which commit to checkout and run the workflow against.
* Updated the `Checkout Repository` step to use the provided `commit_sha` input, ensuring the workflow runs on the intended commit rather than always defaulting to the latest on `main`.Add manual trigger with commit SHA input to workflow